### PR TITLE
Improve numeric_send and handle decimal scale correctly

### DIFF
--- a/tests/test_typeconversion.py
+++ b/tests/test_typeconversion.py
@@ -4,7 +4,6 @@ import datetime
 import decimal
 import struct
 from .connection_settings import db_connect
-from contextlib import closing
 
 db = dbapi.connect(**db_connect)
 
@@ -215,6 +214,10 @@ class Tests(unittest.TestCase):
         self.cursor.execute("SELECT 5000::numeric")
         retval = self.cursor.fetchall()
         self.assert_(retval[0][0] == decimal.Decimal("5000"),
+                "retrieved value match failed")
+        self.cursor.execute("SELECT 50.34::numeric")
+        retval = self.cursor.fetchall()
+        self.assert_(str(retval[0][0]) == "50.34",
                 "retrieved value match failed")
 
     def testInt2Out(self):


### PR DESCRIPTION
Hi Mathieu, I came across a bug in pg8000 where for example the numeric '50.34' in the db would be returned as '50.3400'. I think I've worked out what's going on, and this pull request should fix it. I've added a test for the bug. Let me know if there are any changes you'd like me to make.

Cheers,

Tony.
