### PR TITLE
Fixed ValueError when running SELECT on RedShift Amazon service

### DIFF
--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -1588,6 +1588,9 @@ class Connection(object):
         values = data.split(b(" "))
         if values[0] in self._commands_with_count:
             ps.cmd['command'] = values[0]
+            if len(values) == 1:
+                # redshift retuns only 1 for SELECT
+                return
             row_count = int(values[-1])
             if ps.row_count == -1:
                 ps.row_count = row_count


### PR DESCRIPTION
I didn't really understand what is `values` in this function, but the fact is that when running SELECT on Redshift, it `values` is equals `['SELECT']` so there isn't a way to get the `values[1]` as integer.

My fix is just to skip this, the only drawback is that the `row_count` won't be set.

I'm open for suggestion for a better approach here. :-)
