### PR TITLE
pg8000.core.text_out(): ensure we're dealing with a string object

### DIFF
--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -1350,7 +1350,7 @@ class Connection(object):
         self.ParameterStatusReceived += self.handle_PARAMETER_STATUS
 
         def text_out(v):
-            return v.encode(self._client_encoding)
+            return str(v).encode(self._client_encoding)
 
         def time_out(v):
             return v.isoformat().encode(self._client_encoding)


### PR DESCRIPTION
in some cases an int is passed to `text_out()` so this converts it to a string.  i'm not sure why it happens, sorry.