### PR TITLE
Corrected missing brackets which resulted in mistakenly passing in a …

### DIFF
--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -636,7 +636,7 @@ def timestamp_send_integer(v):
 
 # data is double-precision float representing seconds since 2000-01-01
 def timestamp_send_float(v):
-    return d_pack(timegm(v.timetuple) + v.microsecond / 1e6 - EPOCH_SECONDS)
+    return d_pack(timegm(v.timetuple()) + v.microsecond / 1e6 - EPOCH_SECONDS)
 
 
 def timestamptz_send_integer(v):


### PR DESCRIPTION
…method instead of actually calling the

method and passing in a tuple, when sending timestamp as a float. This
issue only happens when connecting to certain versions of PostGres
(including v8.3) that use the method 'timestamp_send_float'