### PR TITLE
Fix #113. Don't rollback when not in a transaction.

### DIFF
--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -1739,6 +1739,8 @@ class Connection(object):
         <http://www.python.org/dev/peps/pep-0249/>`_.
         """
         with self._lock:
+            if not self.in_transaction:
+                return
             self.execute(self._cursor, "rollback", None)
 
     def _close(self):

--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -1293,7 +1293,7 @@ class Connection(object):
         # An event handler that is fired when the database server issues a
         # notice.
         # The value of this property is a MulticastDelegate. A callback
-        # can be added by using connection.NotificationReceived += SomeMethod.
+        # can be added by using connection.NoticeReceived += SomeMethod.
         # The method will be called with a single argument, an object that has
         # properties: severity, code, msg, and possibly others (detail, hint,
         # position, where, file, line, and routine). Callbacks can be removed

--- a/pg8000/tests/test_query.py
+++ b/pg8000/tests/test_query.py
@@ -376,9 +376,9 @@ class Tests(unittest.TestCase):
             self.db.execute(cursor, "rollback", None)
 
             self.assertEqual(1, len(notices))
-            # 25P01 is the code for no_active_sql_tronsaction. It has a message
-            # and severity name, but those might be localized/depend on the server
-            # version.
+            # 25P01 is the code for no_active_sql_tronsaction. It has
+            # a message and severity name, but those might be
+            # localized/depend on the server version.
             self.assertEqual(notices[0].get(b'C'), b'25P01')
 
             notices.pop()

--- a/pg8000/tests/test_query.py
+++ b/pg8000/tests/test_query.py
@@ -364,5 +364,34 @@ class Tests(unittest.TestCase):
         finally:
             cursor.close()
 
+    # rolling back when not in a transaction doesn't generate a warning
+    def test_rollback_no_transaction(self):
+        try:
+            cursor = self.db.cursor()
+
+            notices = []
+            self.db.NoticeReceived += notices.append
+
+            # First, verify that a raw rollback does produce a notice
+            self.db.execute(cursor, "rollback", None)
+
+            self.assertEqual(1, len(notices))
+            # 25P01 is the code for no_active_sql_tronsaction. It has a message
+            # and severity name, but those might be localized/depend on the server
+            # version.
+            self.assertEqual(notices[0].get(b'C'), b'25P01')
+
+            notices.pop()
+
+            # Now going through the rollback method doesn't produce
+            # any notices because it knows we're not in a transaction.
+            self.db.rollback()
+
+            self.assertEqual(0, len(notices))
+
+        finally:
+            cursor.close()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I didn't see a good place to add a test specifically for this but I can if somebody shows me the way.
