### PR TITLE
Add a Docker image containing all test dependencies

### DIFF
--- a/Dockerfile-test-env
+++ b/Dockerfile-test-env
@@ -1,0 +1,43 @@
+# Close match to CircleCI's test environment
+FROM ubuntu:12.04
+
+RUN groupadd -r postgres && useradd -r -g postgres postgres
+ADD circleci/*.sh /home/postgres/pg8000/circleci/
+RUN mkdir -p /home/postgres/bin && chown -R postgres:postgres /home/postgres
+WORKDIR /home/postgres/pg8000
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y libossp-uuid16 libossp-uuid-dev libssl-dev wget bzip2 \
+    libreadline-dev libgss3 libgss-dev libxml2 libxml2-dev libkrb5-3 libkrb5-dev build-essential \
+    ca-certificates unzip openjdk-7-jre-headless python-pip && \
+  pip install tox && \
+  su postgres -c " \
+  bash ./circleci/install-postgresql-9.1.22.sh && \
+  bash ./circleci/install-postgresql-9.2.17.sh && \
+  bash ./circleci/install-postgresql-9.3.13.sh && \
+  bash ./circleci/install-postgresql-9.4.8.sh && \
+  bash ./circleci/install-postgresql-9.5.3.sh && \
+  bash ./circleci/install-python-2.7.9.sh && \
+  bash ./circleci/install-python-3.3.5.sh && \
+  bash ./circleci/install-python-3.4.2.sh && \
+  bash ./circleci/install-python-3.5.1.sh && \
+  bash ./circleci/install-pypy-2.4.0.sh && \
+  bash ./circleci/install-pypy3-2.3.1.sh && \
+  bash ./circleci/install-jython-2.7.0.sh \
+  " && \
+  DEBIAN_FRONTEND=noninteractive apt-get remove -y libossp-uuid-dev wget bzip2 libreadline-dev \
+    libgss-dev libxml2-dev libkrb5-dev build-essential unzip && \
+  DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+  rm -rf /var/lib/apt/lists/*
+
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/postgres/bin
+
+ENV PG8000_TEST_NAME=PG8000_TEST_9_5
+ENV PG8000_TEST_9_1="{\"user\": \"postgres\", \"password\": \"pw\", \"port\": 5491}"
+ENV PG8000_TEST_9_2="{\"user\": \"postgres\", \"password\": \"pw\", \"port\": 5492}"
+ENV PG8000_TEST_9_3="{\"user\": \"postgres\", \"password\": \"pw\", \"port\": 5493}"
+ENV PG8000_TEST_9_4="{\"user\": \"postgres\", \"password\": \"pw\", \"port\": 5494}"
+ENV PG8000_TEST_9_5="{\"user\": \"postgres\", \"password\": \"pw\", \"port\": 5495}"
+
+USER postgres
+CMD bash ./circleci/run-postgres-and-tox.sh

--- a/README.creole
+++ b/README.creole
@@ -17,7 +17,19 @@ Links:
 
 =Regression Tests
 
-To run the regression tests, install [[http://testrun.org/tox/latest/|tox]]:
+The easiest way to run the regression tests is using a prebuilt Docker image
+that contains all of the supported versions of Python, Jython, PyPy, and
+PostgreSQL, ready-to-run.  To use this, just mount your source directory
+(where you checked out pg8000 to) onto the image in /home/postgres/pg8000-src,
+and then run the mfenniak/pg8000-test-env image.  Here's a simple
+command-line:
+
+{{{
+docker run -v `pwd`:/home/postgres/pg8000-src mfenniak/pg8000-test-env
+}}}
+
+If you don't have Docker, or want to run the tests in a different environment,
+install [[http://testrun.org/tox/latest/|tox]]:
 
 {{{
 pip install tox

--- a/circleci/install-jython-2.7.0.sh
+++ b/circleci/install-jython-2.7.0.sh
@@ -10,6 +10,7 @@ if [[ ! -e jython-2.7.0/bin/jython ]]; then
     unzip $BUILDROOT/jython-installer-2.7.0.jar
     chmod +x ./bin/jython
     cd $BUILDROOT
+    rm -f jython-installer-2.7.0.jar
 fi
 
 ln -s $BUILDROOT/jython-2.7.0/bin/jython ~/bin/

--- a/circleci/install-postgresql-9.5.3.sh
+++ b/circleci/install-postgresql-9.5.3.sh
@@ -6,3 +6,6 @@ PG_VERSION=9.5.3
 PG_PORT=5495
 
 source $BUILDROOT/circleci/install-postgresql-generic.sh
+
+# Create a second PostgreSQL DB instance, which we'll run on port 5432 to enable doctests
+./pgsql-9.5.3/bin/initdb -U postgres -E UTF8 $BUILDROOT/pgsql-9.5.3/data2

--- a/circleci/install-postgresql-generic.sh
+++ b/circleci/install-postgresql-generic.sh
@@ -9,6 +9,7 @@ if [[ ! -e pgsql-${PG_VERSION}/bin/postgres ]]; then
     make world
     make install-world
     cd $BUILDROOT
+    rm -rf postgresql-${PG_VERSION}.tar.bz2 postgresql-${PG_VERSION} # remove source tarball & build dir
     ./pgsql-${PG_VERSION}/bin/initdb -U postgres `pwd`/pgsql-${PG_VERSION}/data
 
     sed -i -e "s/#port = 5432/port = ${PG_PORT}/" `pwd`/pgsql-${PG_VERSION}/data/postgresql.conf

--- a/circleci/install-postgresql-generic.sh
+++ b/circleci/install-postgresql-generic.sh
@@ -10,7 +10,7 @@ if [[ ! -e pgsql-${PG_VERSION}/bin/postgres ]]; then
     make install-world
     cd $BUILDROOT
     rm -rf postgresql-${PG_VERSION}.tar.bz2 postgresql-${PG_VERSION} # remove source tarball & build dir
-    ./pgsql-${PG_VERSION}/bin/initdb -U postgres `pwd`/pgsql-${PG_VERSION}/data
+    ./pgsql-${PG_VERSION}/bin/initdb -U postgres -E UTF8 `pwd`/pgsql-${PG_VERSION}/data
 
     sed -i -e "s/#port = 5432/port = ${PG_PORT}/" `pwd`/pgsql-${PG_VERSION}/data/postgresql.conf
     sed -i -e "s/#ssl = off/ssl = on/" `pwd`/pgsql-${PG_VERSION}/data/postgresql.conf

--- a/circleci/install-pypy-2.4.0.sh
+++ b/circleci/install-pypy-2.4.0.sh
@@ -6,6 +6,7 @@ BUILDROOT=$HOME/pg8000
 if [[ ! -e pypy-2.4.0-linux64/bin/pypy ]]; then
     wget https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-linux64.tar.bz2
     tar -jxf pypy-2.4.0-linux64.tar.bz2
+    rm -f pypy-2.4.0-linux64.tar.bz2
 fi
 
 ln -s $BUILDROOT/pypy-2.4.0-linux64/bin/pypy ~/bin/

--- a/circleci/install-pypy3-2.3.1.sh
+++ b/circleci/install-pypy3-2.3.1.sh
@@ -6,6 +6,7 @@ BUILDROOT=$HOME/pg8000
 if [[ ! -e pypy3-2.3.1-linux64/bin/pypy ]]; then
     wget https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-linux64.tar.bz2
     tar -jxf pypy3-2.3.1-linux64.tar.bz2
+    rm -f pypy3-2.3.1-linux64.tar.bz2
 fi
 
 ln -s $BUILDROOT/pypy3-2.3.1-linux64/bin/pypy ~/bin/pypy3

--- a/circleci/install-python-2.7.9.sh
+++ b/circleci/install-python-2.7.9.sh
@@ -10,6 +10,7 @@ if [[ ! -e py-2.7.9/bin/python2.7 ]]; then
     ./configure --prefix=$BUILDROOT/py-2.7.9
     make install
     cd $BUILDROOT
+    rm -rf ./Python-2.7.9.tgz ./Python-2.7.9
 fi
 
 ln -s $BUILDROOT/py-2.7.9/bin/python2.7 ~/bin/

--- a/circleci/install-python-3.3.5.sh
+++ b/circleci/install-python-3.3.5.sh
@@ -10,6 +10,7 @@ if [[ ! -e py-3.3.5/bin/python3.3 ]]; then
     ./configure --prefix=$BUILDROOT/py-3.3.5
     make install
     cd $BUILDROOT
+    rm -rf ./Python-3.3.5.tgz ./Python-3.3.5
 fi
 
 ln -s $BUILDROOT/py-3.3.5/bin/python3.3 ~/bin/

--- a/circleci/install-python-3.4.2.sh
+++ b/circleci/install-python-3.4.2.sh
@@ -10,6 +10,7 @@ if [[ ! -e py-3.4.2/bin/python3.4 ]]; then
     ./configure --prefix=$BUILDROOT/py-3.4.2
     make install
     cd $BUILDROOT
+    rm -rf ./Python-3.4.2.tgz ./Python-3.4.2
 fi
 
 ln -s $BUILDROOT/py-3.4.2/bin/python3.4 ~/bin/

--- a/circleci/install-python-3.5.1.sh
+++ b/circleci/install-python-3.5.1.sh
@@ -10,6 +10,7 @@ if [[ ! -e py-3.5.1/bin/python3.5 ]]; then
     ./configure --prefix=$BUILDROOT/py-3.5.1
     make install
     cd $BUILDROOT
+    rm -rf ./Python-3.5.1.tgz ./Python-3.5.1
 fi
 
 ln -s $BUILDROOT/py-3.5.1/bin/python3.5 ~/bin/

--- a/circleci/run-postgres-and-tox.sh
+++ b/circleci/run-postgres-and-tox.sh
@@ -1,0 +1,8 @@
+./pgsql-9.1.22/bin/postgres -D `pwd`/pgsql-9.1.22/data -p 5491 &> pgsql-9.1.log
+./pgsql-9.2.17/bin/postgres -D `pwd`/pgsql-9.2.17/data -p 5492 &> pgsql-9.2.log
+./pgsql-9.3.13/bin/postgres -D `pwd`/pgsql-9.3.13/data -p 5493 &> pgsql-9.3.log
+./pgsql-9.4.8/bin/postgres -D `pwd`/pgsql-9.4.8/data -p 5494 &> pgsql-9.4.log
+./pgsql-9.5.3/bin/postgres -D `pwd`/pgsql-9.5.3/data -p 5495 &> pgsql-9.5.log
+
+cd ~postgres/pg8000-src/
+tox

--- a/circleci/run-postgres-and-tox.sh
+++ b/circleci/run-postgres-and-tox.sh
@@ -3,6 +3,7 @@
 ./pgsql-9.3.13/bin/postgres -D `pwd`/pgsql-9.3.13/data -p 5493 &> pgsql-9.3.log &
 ./pgsql-9.4.8/bin/postgres -D `pwd`/pgsql-9.4.8/data -p 5494 &> pgsql-9.4.log &
 ./pgsql-9.5.3/bin/postgres -D `pwd`/pgsql-9.5.3/data -p 5495 &> pgsql-9.5.log &
+./pgsql-9.5.3/bin/postgres -D `pwd`/pgsql-9.5.3/data2 -p 5432 &> pgsql-9.5-data2.log &
 
 cd ~postgres/pg8000-src/
 tox

--- a/circleci/run-postgres-and-tox.sh
+++ b/circleci/run-postgres-and-tox.sh
@@ -1,8 +1,8 @@
-./pgsql-9.1.22/bin/postgres -D `pwd`/pgsql-9.1.22/data -p 5491 &> pgsql-9.1.log
-./pgsql-9.2.17/bin/postgres -D `pwd`/pgsql-9.2.17/data -p 5492 &> pgsql-9.2.log
-./pgsql-9.3.13/bin/postgres -D `pwd`/pgsql-9.3.13/data -p 5493 &> pgsql-9.3.log
-./pgsql-9.4.8/bin/postgres -D `pwd`/pgsql-9.4.8/data -p 5494 &> pgsql-9.4.log
-./pgsql-9.5.3/bin/postgres -D `pwd`/pgsql-9.5.3/data -p 5495 &> pgsql-9.5.log
+./pgsql-9.1.22/bin/postgres -D `pwd`/pgsql-9.1.22/data -p 5491 &> pgsql-9.1.log &
+./pgsql-9.2.17/bin/postgres -D `pwd`/pgsql-9.2.17/data -p 5492 &> pgsql-9.2.log &
+./pgsql-9.3.13/bin/postgres -D `pwd`/pgsql-9.3.13/data -p 5493 &> pgsql-9.3.log &
+./pgsql-9.4.8/bin/postgres -D `pwd`/pgsql-9.4.8/data -p 5494 &> pgsql-9.4.log &
+./pgsql-9.5.3/bin/postgres -D `pwd`/pgsql-9.5.3/data -p 5495 &> pgsql-9.5.log &
 
 cd ~postgres/pg8000-src/
 tox


### PR DESCRIPTION
This should allow contributors to more easily run the integration test suite in all the same configurations as CircleCI runs.