### PR TITLE
Cursor as context manager

### DIFF
--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -838,6 +838,12 @@ class Cursor():
         self.portal_name = None
         self.portal_suspended = False
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
     @property
     def connection(self):
         warn("DB-API extension cursor.connection used", stacklevel=3)

--- a/pg8000/tests/test_query.py
+++ b/pg8000/tests/test_query.py
@@ -1,7 +1,7 @@
 import unittest
 import threading
 import pg8000
-from pg8000.tests.connection_settings import db_connect
+from .connection_settings import db_connect
 from six import u
 from sys import exc_info
 import datetime

--- a/pg8000/tests/test_query.py
+++ b/pg8000/tests/test_query.py
@@ -1,7 +1,7 @@
 import unittest
 import threading
 import pg8000
-from .connection_settings import db_connect
+from pg8000.tests.connection_settings import db_connect
 from six import u
 from sys import exc_info
 import datetime
@@ -391,6 +391,13 @@ class Tests(unittest.TestCase):
 
         finally:
             cursor.close()
+
+    def test_context_manager_class(self):
+        self.assertTrue('__enter__' in pg8000.core.Cursor.__dict__)
+        self.assertTrue('__exit__' in pg8000.core.Cursor.__dict__)
+
+        with self.db.cursor() as cursor:
+            cursor.execute('select 1');
 
 
 if __name__ == "__main__":

--- a/pg8000/tests/test_query.py
+++ b/pg8000/tests/test_query.py
@@ -397,7 +397,7 @@ class Tests(unittest.TestCase):
         self.assertTrue('__exit__' in pg8000.core.Cursor.__dict__)
 
         with self.db.cursor() as cursor:
-            cursor.execute('select 1');
+            cursor.execute('select 1')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi!

Here is the patch that adds a context manager interface to the `Cursor` class. So it can be used with `with` statement like:

```
with connection.cursor() as cur:
    cur.execute(query)
```

And another point is that it would be easier to switch from `psycopg2` which implements context manager interface.