### PR TITLE
For postgresql 9.6+, exclude the new non-localized 'severity' field

### DIFF
--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -1620,7 +1620,7 @@ class Connection(object):
     def handle_ERROR_RESPONSE(self, data, ps):
         msg = OrderedDict(
             (s[:1], s[1:].decode(self._client_encoding)) for s in
-            data.split(NULL_BYTE) if s != b(''))
+            data.split(NULL_BYTE) if s != b('') and s[:1] != b('V'))
         exc_args = itervalues(msg)
         if msg[RESPONSE_CODE] == "28000":
             self.error = InterfaceError(*exc_args)

--- a/pg8000/tests/test_typeconversion.py
+++ b/pg8000/tests/test_typeconversion.py
@@ -233,12 +233,12 @@ class Tests(unittest.TestCase):
         try:
             import ipaddress
 
-            v = ipaddress.ip_network('192.168.0.0/28')
+            v = ipaddress.ip_network(u'192.168.0.0/28')
             self.cursor.execute("select %s as f1", (v,))
             retval = self.cursor.fetchall()
             self.assertEqual(retval[0][0], v)
 
-            v = ipaddress.ip_address('192.168.0.1')
+            v = ipaddress.ip_address(u'192.168.0.1')
             self.cursor.execute("select %s as f1", (v,))
             retval = self.cursor.fetchall()
             self.assertEqual(retval[0][0], v)


### PR DESCRIPTION
Postgres 9.6 introduces a new field to [Postgres error messages](https://www.postgresql.org/docs/9.6/static/protocol-error-fields.html)

This results in a lot of errors of the form:
`    self.assertEqual(e.args[1], '42P01')  # table does not exist`
`AssertionError: u'ERROR' != '42P01'`

This path just excludes the new field from the set of arguments that get passed into downstream Exceptions.