### PR TITLE
Update handling of integer keys

### DIFF
--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -1878,7 +1878,7 @@ class Connection(object):
         params = []
         for value in values:
             typ = type(value)
-            if issubclass(typ, integer_types):
+            if type != bool and issubclass(typ, integer_types):
                 oid, fc, send_func = _get_integer_pack_for_values([value])
                 if oid is None:
                     raise NotSupportedError(

--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -1881,7 +1881,9 @@ class Connection(object):
             if issubclass(typ, integer_types):
                 oid, fc, send_func = _get_integer_pack_for_values([value])
                 if oid is None:
-                    raise NotSupportedError(str(value) + " cannot be converted to a postgres integer value")
+                    raise NotSupportedError(
+                        str(value) +
+                        " cannot be converted to a postgres integer value")
                 params.append((oid, fc, send_func))
             else:
                 try:
@@ -2203,7 +2205,8 @@ class Connection(object):
         if issubclass(typ, integer_types):
             # special int array support -- send as smallest possible array type
             typ = integer_types
-            oid, fc, send_func = _get_integer_pack_for_values(array_flatten(value))
+            oid, fc, send_func = _get_integer_pack_for_values(
+                array_flatten(value))
             if oid is None:
                 raise ArrayContentNotSupportedError(
                     "numeric not supported as array contents")

--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -1878,7 +1878,7 @@ class Connection(object):
         params = []
         for value in values:
             typ = type(value)
-            if type != bool and issubclass(typ, integer_types):
+            if typ != bool and issubclass(typ, integer_types):
                 oid, fc, send_func = _get_integer_pack_for_values([value])
                 if oid is None:
                     raise NotSupportedError(

--- a/pg8000/tests/test_typeconversion.py
+++ b/pg8000/tests/test_typeconversion.py
@@ -117,6 +117,12 @@ class Tests(unittest.TestCase):
         retval = self.cursor.fetchall()
         self.assertEqual(retval[0][0], v)
 
+    def testLongRoundtripNoCast(self):
+        self.cursor.execute(
+            "SELECT %s", (50000000000000,))
+        retval = self.cursor.fetchall()
+        self.assertEqual(retval[0][0], 50000000000000)
+
     def testLongRoundtrip(self):
         self.cursor.execute(
             "SELECT cast(%s as bigint)", (50000000000000,))
@@ -124,7 +130,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(retval[0][0], 50000000000000)
 
     def testIntExecuteMany(self):
-        self.cursor.executemany("SELECT cast(%s as integer)", ((1,), (40000,)))
+        self.cursor.executemany("SELECT %s", ((1,), (40000,)))
         self.cursor.fetchall()
 
         v = ([None], [4])
@@ -152,6 +158,13 @@ class Tests(unittest.TestCase):
             (+2147483648, int8, 'bigint'),
             (-9223372036854775807, int8, 'bigint'),
             (+9223372036854775807, int8, 'bigint'), ]
+
+        for value, typoid, _ in test_values:
+            self.cursor.execute("SELECT %s", (value,))
+            retval = self.cursor.fetchall()
+            self.assertEqual(retval[0][0], value)
+            column_name, column_typeoid = self.cursor.description[0][0:2]
+            self.assertEqual(column_typeoid, typoid)
 
         for value, typoid, tp in test_values:
             self.cursor.execute("SELECT cast(%s as " + tp + ")", (value,))
@@ -354,6 +367,11 @@ class Tests(unittest.TestCase):
             self.cursor.execute("SELECT " + num + "::numeric")
             retval = self.cursor.fetchall()
             self.assertEqual(str(retval[0][0]), num)
+
+    def testIntOutNoCast(self):
+        self.cursor.execute("SELECT 5000")
+        retval = self.cursor.fetchall()
+        self.assertEqual(retval[0][0], 5000)
 
     def testInt2Out(self):
         self.cursor.execute("SELECT 5000::smallint")

--- a/pg8000/tests/test_typeconversion.py
+++ b/pg8000/tests/test_typeconversion.py
@@ -687,28 +687,32 @@ class Tests(unittest.TestCase):
     def testJsonAccessObject(self):
         if self.db._server_version >= LooseVersion('9.4'):
             val = {'name': 'Apollo 11 Cave', 'zebra': True, 'age': 26.003}
-            self.cursor.execute("SELECT cast(%s as json) -> %s", (json.dumps(val), 'name'))
+            self.cursor.execute(
+                "SELECT cast(%s as json) -> %s", (json.dumps(val), 'name'))
             retval = self.cursor.fetchall()
             self.assertEqual(retval[0][0], 'Apollo 11 Cave')
 
     def testJsonbAccessObject(self):
         if self.db._server_version >= LooseVersion('9.4'):
             val = {'name': 'Apollo 11 Cave', 'zebra': True, 'age': 26.003}
-            self.cursor.execute("SELECT cast(%s as jsonb) -> %s", (json.dumps(val), 'name'))
+            self.cursor.execute(
+                "SELECT cast(%s as jsonb) -> %s", (json.dumps(val), 'name'))
             retval = self.cursor.fetchall()
             self.assertEqual(retval[0][0], 'Apollo 11 Cave')
 
     def testJsonAccessArray(self):
         if self.db._server_version >= LooseVersion('9.4'):
             val = [-1, -2, -3, -4, -5]
-            self.cursor.execute("SELECT cast(%s as json) -> %s", (json.dumps(val), 2))
+            self.cursor.execute(
+                "SELECT cast(%s as json) -> %s", (json.dumps(val), 2))
             retval = self.cursor.fetchall()
             self.assertEqual(retval[0][0], -3)
 
     def testJsonbAccessArray(self):
         if self.db._server_version >= LooseVersion('9.4'):
             val = [-1, -2, -3, -4, -5]
-            self.cursor.execute("SELECT cast(%s as jsonb) -> %s", (json.dumps(val), 2))
+            self.cursor.execute(
+                "SELECT cast(%s as jsonb) -> %s", (json.dumps(val), 2))
             retval = self.cursor.fetchall()
             self.assertEqual(retval[0][0], -3)
 

--- a/pg8000/tests/test_typeconversion.py
+++ b/pg8000/tests/test_typeconversion.py
@@ -42,6 +42,17 @@ class Tests(unittest.TestCase):
         retval = self.cursor.fetchall()
         self.assertEqual(retval[0][0], True)
 
+    def testBoolInsertRoundtrip(self):
+        self.cursor.execute(
+            "CREATE TEMPORARY TABLE TestBoolWrite "
+            "(f1 bool, f2 bool)")
+        self.cursor.execute(
+            "INSERT INTO TestBoolWrite VALUES (%s, %s)",
+            (True, False))
+        self.cursor.execute("SELECT * FROM TestBoolWrite")
+        retval = self.cursor.fetchone()
+        self.assertEqual(retval, [True, False])
+
     def testNullRoundtrip(self):
         # We can't just "SELECT %s" and set None as the parameter, since it has
         # no type.  That would result in a PG error, "could not determine data

--- a/pg8000/tests/test_typeconversion.py
+++ b/pg8000/tests/test_typeconversion.py
@@ -684,6 +684,34 @@ class Tests(unittest.TestCase):
             retval = self.cursor.fetchall()
             self.assertEqual(retval[0][0], val)
 
+    def testJsonAccessObject(self):
+        if self.db._server_version >= LooseVersion('9.4'):
+            val = {'name': 'Apollo 11 Cave', 'zebra': True, 'age': 26.003}
+            self.cursor.execute("SELECT cast(%s as json) -> %s", (json.dumps(val), 'name'))
+            retval = self.cursor.fetchall()
+            self.assertEqual(retval[0][0], 'Apollo 11 Cave')
+
+    def testJsonbAccessObject(self):
+        if self.db._server_version >= LooseVersion('9.4'):
+            val = {'name': 'Apollo 11 Cave', 'zebra': True, 'age': 26.003}
+            self.cursor.execute("SELECT cast(%s as jsonb) -> %s", (json.dumps(val), 'name'))
+            retval = self.cursor.fetchall()
+            self.assertEqual(retval[0][0], 'Apollo 11 Cave')
+
+    def testJsonAccessArray(self):
+        if self.db._server_version >= LooseVersion('9.4'):
+            val = [-1, -2, -3, -4, -5]
+            self.cursor.execute("SELECT cast(%s as json) -> %s", (json.dumps(val), 2))
+            retval = self.cursor.fetchall()
+            self.assertEqual(retval[0][0], -3)
+
+    def testJsonbAccessArray(self):
+        if self.db._server_version >= LooseVersion('9.4'):
+            val = [-1, -2, -3, -4, -5]
+            self.cursor.execute("SELECT cast(%s as jsonb) -> %s", (json.dumps(val), 2))
+            retval = self.cursor.fetchall()
+            self.assertEqual(retval[0][0], -3)
+
     def test_timestamp_send_float(self):
         assert b('A\xbe\x19\xcf\x80\x00\x00\x00') == \
             pg8000.core.timestamp_send_float(


### PR DESCRIPTION
This error manifested by trying to access elements in JSON/JSONB arrays. Array access fails because the integers are casted as strings and the array reference is interpreted as an object access without an explicit cast (as seen in https://github.com/mfenniak/pg8000/issues/124)