### PR TITLE
Fix calculation of array dimensions

### DIFF
--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -2298,7 +2298,7 @@ def array_dim_lengths(arr):
     if len_arr > 0:
         v0 = arr[0]
         if isinstance(v0, list):
-            retval = [len(v0)]
+            retval = [len_arr]
             retval.extend(array_dim_lengths(v0))
             return retval
     return [len_arr]


### PR DESCRIPTION
The calculation of array dimensions omitted the length of the first dimension,
instead using the second dimension twice. For example, consider the value `[[1,
2], [3, 4], [5, 6]]`. We would expect `array_dim_lengths` to return `(3, 2)`. In
the prior version, we would compute `len_arr` as `3`, but initialize `retval`
with `[len(v0)]`. The end result is that we get `(2, 2)`. Substituting `len_arr`
for `len(v0)` is sufficient to fix this issue.