### PR TITLE
Get the current OS user

### DIFF
--- a/pg8000/__init__.py
+++ b/pg8000/__init__.py
@@ -41,7 +41,7 @@ __author__ = "Mathieu Fenniak"
 
 
 def connect(
-        user, host='localhost', unix_sock=None, port=5432, database=None,
+        user=None, host='localhost', unix_sock=None, port=5432, database=None,
         password=None, ssl=False, timeout=None, application_name=None):
     """Creates a connection to a PostgreSQL database.
 
@@ -51,6 +51,10 @@ def connect(
 
     :param user:
         The username to connect to the PostgreSQL server with.
+
+        Can be None if ``host`` is None and ``unix_sock`` is not None;
+        in that case ``user`` will be assumed the current OS user
+        as returned by `getpass.getuser()`.
 
         If your server character encoding is not ``ascii`` or ``utf8``, then
         you need to provide ``user`` as bytes, eg.

--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -1,3 +1,4 @@
+from getpass import getuser
 from datetime import (
     timedelta as Timedelta, datetime as Datetime, tzinfo, date, time)
 from warnings import warn
@@ -1051,6 +1052,15 @@ IDLE_IN_FAILED_TRANSACTION = b("E")
 arr_trans = dict(zip(map(ord, u("[] 'u")), list(u('{}')) + [None] * 3))
 
 
+def _getuser():
+    # ``getuser()`` on w32 can raise ``ImportError``
+    # due to absent of ``pwd`` module.
+    try:
+        return getuser()
+    except ImportError:
+        return None
+
+
 class Connection(object):
 
     # DBAPI Extension: supply exceptions as attributes on the connection
@@ -1081,6 +1091,9 @@ class Connection(object):
         self.notifications = deque(maxlen=100)
         self.notices = deque(maxlen=100)
         self.parameter_statuses = deque(maxlen=100)
+
+        if user is None and host is None and unix_sock is not None:
+            user = _getuser()
 
         if user is None:
             raise InterfaceError(


### PR DESCRIPTION
If ``user`` is None and ``host`` is None and ``unix_sock`` is not None
assume ``user`` to be the current OS user as returned by `getpass.getuser()`.