### PR TITLE
Correctly process type conversion when it's used with named or numeric parameter style. 

### DIFF
--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -451,9 +451,20 @@ def convert_paramstyle(style, query):
                 state = INSIDE_QI
             elif style == "qmark" and c == "?":
                 output_query.append(next(param_idx))
-            elif style == "numeric" and c == ":":
+            elif style == "numeric" \
+                    and c == ":" \
+                    and next_c != ':' \
+                    and prev_c != ':':
+                # Treat : as beginning of parameter name if and only
+                # if it's the only : around
+                # Needed to properly process type conversions
+                # i.e. sum(x)::float
                 output_query.append("$")
-            elif style == "named" and c == ":":
+            elif style == "named" \
+                    and c == ":" \
+                    and next_c != ':' \
+                    and prev_c != ':':
+                # Same logic for : as in numeric parameters
                 state = INSIDE_PN
                 placeholders.append('')
             elif style == "pyformat" and c == '%' and next_c == "(":

--- a/tests/test_paramstyle.py
+++ b/tests/test_paramstyle.py
@@ -23,14 +23,14 @@ class Tests(unittest.TestCase):
 
     def testNumeric(self):
         new_query, make_args = pg8000.core.convert_paramstyle(
-            "numeric", "SELECT :2, :1, * FROM t WHERE a=:3")
-        self.assertEqual(new_query, "SELECT $2, $1, * FROM t WHERE a=$3")
+            "numeric", "SELECT sum(x)::decimal(5, 2) :2, :1, * FROM t WHERE a=:3")
+        self.assertEqual(new_query, "SELECT sum(x)::decimal(5, 2) $2, $1, * FROM t WHERE a=$3")
         self.assertEqual(make_args((1, 2, 3)), (1, 2, 3))
 
     def testNamed(self):
         new_query, make_args = pg8000.core.convert_paramstyle(
-            "named", "SELECT :f_2, :f1 FROM t WHERE a=:f_2")
-        self.assertEqual(new_query, "SELECT $1, $2 FROM t WHERE a=$1")
+            "named", "SELECT sum(x)::decimal(5, 2) :f_2, :f1 FROM t WHERE a=:f_2")
+        self.assertEqual(new_query, "SELECT sum(x)::decimal(5, 2) $1, $2 FROM t WHERE a=$1")
         self.assertEqual(make_args({"f_2": 1, "f1": 2}), (1, 2))
 
     def testFormat(self):


### PR DESCRIPTION
The gist is to treat ':' as a signal to change state for named/numeric parameters if and only if it's the only ':' around, to avoid confusing type conversions in queries with the parameter definitions.  
Fix for #142