### PR TITLE
Add flag to enable TCP Keepalives when connecting

### DIFF
--- a/pg8000/__init__.py
+++ b/pg8000/__init__.py
@@ -42,7 +42,8 @@ __author__ = "Mathieu Fenniak"
 
 def connect(
         user, host='localhost', unix_sock=None, port=5432, database=None,
-        password=None, ssl=False, timeout=None, application_name=None):
+        password=None, ssl=False, timeout=None, application_name=None,
+        tcp_keep_alive=False):
     """Creates a connection to a PostgreSQL database.
 
     This function is part of the `DBAPI 2.0 specification
@@ -103,12 +104,21 @@ def connect(
         connection to the database will time out. The default is ``None`` which
         means no timeout.
 
+    :keyword tcp_keep_alive:
+        This is to enable TCP keepalives for the connection to the database.
+        These help maintain a connection when long running queries are issued
+        or when no statements are issued for an extended period of time. By
+        default these keepalives are not enabled when you set to ``True`` then
+        the connection will send keep-alives.  How often these keepalives are
+        sent and how many can be missed before a connection is deemed broken
+        is an OS setting.
+
     :rtype:
         A :class:`Connection` object.
     """
     return Connection(
         user, host, unix_sock, port, database, password, ssl, timeout,
-        application_name)
+        application_name, tcp_keep_alive)
 
 
 apilevel = "2.0"

--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -1073,7 +1073,7 @@ class Connection(object):
 
     def __init__(
             self, user, host, unix_sock, port, database, password, ssl,
-            timeout, application_name):
+            timeout, application_name, tcp_keep_alive):
         self._client_encoding = "utf8"
         self._commands_with_count = (
             b("INSERT"), b("DELETE"), b("UPDATE"), b("MOVE"),
@@ -1139,6 +1139,9 @@ class Connection(object):
                         "this python installation")
 
             self._sock = self._usock.makefile(mode="rwb")
+            if tcp_keep_alive:
+                self._usock.setsockopt(socket.SOL_SOCKET,
+                                       socket.SO_KEEPALIVE, 1)
         except socket.error as e:
             self._usock.close()
             raise InterfaceError("communication error", e)


### PR DESCRIPTION
Connections that don't have much traffic passing through can get broken by statefull network components if they are IDLE for too long.  On operating System level it is possible to configure keepalive configuration but the application itself needs to enable keepalives on the Network socket (BSD based flavors seem to support enforcing it for all but for example on Linux you don't have that option hence there is a need to be able to configure it).

For backwards compatibility I have put the default to `False` however a default of `True` could avoid issues for people not to familiar with networking issues.

PS: I had some issues using the Docker file, I did some changes in https://github.com/pvbouwel/pg8000/commit/ab40d949c096a46919b0bc76d96d5ef8cddb2448 it seems like the latest commits have removed some files in `circleci` directory that were still referenced from the Dockerfile.  Also the Docker container uses and old version of pip.  Since I still had to run the tests manually by attaching in the container I create a pull request without those changes as I am not sure what the intentions were with the latest commits.  Also to pass all the tests I had to create an additional Postgresql instance on the original port 5432 and with the password `C.P.Snow` for user `postgres` in order to be able to pass the doc tests.

Edit: so this was for issue https://github.com/mfenniak/pg8000/issues/149 