### PR TITLE
Add Python 'with' keyword support for the Connection object

### DIFF
--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -1106,6 +1106,12 @@ class Connection(object):
     NotSupportedError = property(
         lambda self: self._getError(NotSupportedError))
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+        
     def _getError(self, error):
         warn(
             "DB-API extension connection.%s used" %


### PR DESCRIPTION
This allows developers to use:

`with pg8000.connect(**db_connect) as db:`

instead of using a try-finally mechanism with extra checking to ensure they don't attempt to call close on an uninitialized object.