### PR TITLE
Add postgresql 10 to travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,21 @@ python:
 env:
   - DB="9.5"
   - DB="9.6"
+  - DB="10"
 
 services:
   - postgresql
 addons:
   postgresql: "9.5"
   postgresql: "9.6"
+  postgresql: "10"
+  apt:
+    packages:
+    - postgresql-10
+    - postgresql-client-10
+env:
+  global:
+  - PGPORT=5432
 
 before_install:
   - sudo service postgresql stop


### PR DESCRIPTION
Hello,

Following: https://docs.travis-ci.com/user/database-setup/#postgresql

Travis can test with postgresql 10, can be good to test with this version since this is the default version available for download in the postgresql site.

I will setup up some manual testing in a fedora docker cointainer since we have postgresl 11 available in Rawhide:

https://src.fedoraproject.org/rpms/postgresql/blob/master/f/postgresql.spec#_61