### PR TITLE
Include pytz as required for testing in setup file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ setup(
     install_requires=[
         "six>=1.10.0",
     ],
+    tests_require = [
+    "pytz",
+    ],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
The CircleCi are failling by:

======================================================================
ERROR: Failure: ImportError (No module named pytz)
Traceback (most recent call last):
File "/home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/nose/loader.py", line 418, in loadTestsFromName
addr.filename, addr.module)
File "/home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
return self.importFromDir(dir_path, fqname)
File "/home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/nose/importer.py", line 94, in importFromDir
mod = load_module(part_fqname, fh, filename, desc)
File "/home/ubuntu/pg8000/tests/test_typeconversion.py", line 15, in 
import pytz
ImportError: No module named pytz

This is the build: https://circleci.com/gh/mfenniak/pg8000/198?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

This should ensure that pytz is installed before running the tests.

Info:

https://setuptools.readthedocs.io/en/latest/setuptools.html?highlight=tests_require#new-and-changed-setup-keywords
https://stackoverflow.com/questions/15422527/best-practices-how-do-you-list-required-dependencies-in-your-setup-py